### PR TITLE
Twitter card share fix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,9 @@
   <link rel="stylesheet" href="https://assets.webuild.sg/css/style.css">
   {% if page.title == "live notes" %}<link rel="stylesheet" href="/css/prism.css">{% endif %}
 
-  {% if page.profile %}<meta property="og:image" content="{{ site.url }}/img/{{ page.profile }}-profile.jpg">{% endif %}
+
+  {% if page.profile %}<meta property="og:image" content="{{ site.url }}/img/{{ page.profile }}-profile.jpg">
+  {% assign host = site.url | split: "" %}<meta property="twitter:image" content="{% if host[0] == "/" and host[1] == "/" %}http:{% endif %}{{site.url}}/img/{{ page.profile }}-profile.jpg">{% endif %}
   <meta property="og:image" content="{{site.default_logo}}">
   {% if site.next_profile %}<meta property="og:image" content="{{ site.url }}{{ site.next_profile }}">{% endif %}
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">


### PR DESCRIPTION
As images on the Twitter share weren't showing up properly I did some debugging with [the official Twitter Card validator](https://cards-dev.twitter.com/validator) using [this](view-source:https://flaki.github.io/test/twittercard.html) fake testcase as a guinea pig, and managed to pull together a fix so podcaster images should now show up on Twitter shares properly.

The gist of the issue is Twitter seems to require the `twitter:image` meta tag, and also not very fond of universal urls (ones that start with `//`).